### PR TITLE
IDを利用するMutation を実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "kamal", require: false
 gem "thruster", require: false
 
 gem "graphql"
+gem "globalid"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,7 @@ DEPENDENCIES
   brakeman
   cssbundling-rails
   debug
+  globalid
   graphiql-rails
   graphql
   jsbundling-rails

--- a/app/graphql/gql_chat_schema.rb
+++ b/app/graphql/gql_chat_schema.rb
@@ -19,11 +19,19 @@ class GqlChatSchema < GraphQL::Schema
 
   # Return a string UUID for `object`
   def self.id_from_object(object, type_definition, query_ctx)
-    object.to_gid_param
+    object_id = object.to_global_id.to_s
+    # Remove this redundant prefix to make IDs shorter:
+    object_id = object_id.sub("gid://#{GlobalID.app}/", "")
+    encoded_id = Base64.urlsafe_encode64(object_id)
+    # Remove the "=" padding
+    encoded_id.sub(/=+/, "")
   end
 
   # Given a string UUID, find the object
-  def self.object_from_id(global_id, query_ctx)
-    GlobalID.find(global_id)
+  def self.object_from_id(encoded_id, query_ctx)
+    id = Base64.urlsafe_decode64(encoded_id)
+    # Rebuild it for Rails then find the object:
+    full_global_id = "gid://#{GlobalID.app}/#{id}"
+    GlobalID::Locator.locate(full_global_id)
   end
 end

--- a/app/graphql/gql_chat_schema.rb
+++ b/app/graphql/gql_chat_schema.rb
@@ -9,7 +9,7 @@ class GqlChatSchema < GraphQL::Schema
   end
 
   def self.resolve_type(abstract_type, obj, ctx)
-    raise(GraphQL::RequiredImplementationMissingError)
+    abstract_type
   end
 
   max_query_string_tokens(5000)

--- a/app/graphql/mutations/update_message.rb
+++ b/app/graphql/mutations/update_message.rb
@@ -1,0 +1,13 @@
+module Mutations
+  class UpdateMessage < Mutations::Base
+    argument :message_id, ID, required: true, loads: Types::Message
+    argument :content, String, required: true
+
+    field :message, Types::Message, null: false
+
+    def resolve(message:, **args)
+      message.update!(content: args[:content])
+      { message: message }
+    end
+  end
+end

--- a/app/graphql/types/message.rb
+++ b/app/graphql/types/message.rb
@@ -2,7 +2,7 @@ module Types
   class Message < Types::BaseObject
     implements Interfaces::Node
 
-    field :id, ID, null: false
+    global_id_field :id
     field :sender_name, String, null: false
     field :content, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_message, mutation: Mutations::CreateMessage, description: "チャットを投稿する"
+    field :update_message, mutation: Mutations::UpdateMessage, description: "チャットを更新する"
   end
 end


### PR DESCRIPTION
## 変更理由
以下のloadsを参考に実装する
https://graphql-ruby.org/mutations/mutation_classes.html 

## 変更点
- Schema
  - id_from_object , object_from_id , global_idの値を `#{model_name}/#{id}` のBase64にする
  - resolve_type argument loads のために実装する
    - 今はinterfaceがないため `abstract_type` をそのまま返す
- UpdateMessage
  - `argument :message_id, ID, required: true, loads: Types::Message`
    - loads でオブジェクト読み込み
    - この時IDの値は global_id の値 例: `TWVzc2FnZS8zNA`
    - resolveで loads した値を受け取る。
      - IDの `#{type}_id` のtype部分が引数になるため message_id だと message 

